### PR TITLE
Add request/params/response examples using annotations

### DIFF
--- a/employee-service/src/main/java/pl/piomin/services/employee/controller/EmployeeController.java
+++ b/employee-service/src/main/java/pl/piomin/services/employee/controller/EmployeeController.java
@@ -1,5 +1,11 @@
 package pl.piomin.services.employee.controller;
 
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.piomin.services.employee.model.Employee;
@@ -21,7 +27,21 @@ public class EmployeeController {
     EmployeeRepository repository;
 
     @POST
-    public Employee add(@Valid Employee employee) {
+    @APIResponses(value = {
+          @APIResponse(responseCode = "200", content = {
+                @Content(mediaType = "application/json", examples = {
+                      @ExampleObject(name = "add_employee", value = "{\"id\": 4, \"name\": \"Test User 4\", \"age\": 50, \"organizationId\": 2, \"departmentId\": 3, \"position\": \"tester\"}")
+                })
+          })
+    })
+    public Employee add(
+          @RequestBody(content = {
+                @Content(mediaType = "application/json", examples = {
+                      @ExampleObject(name = "add_employee", summary = "Hire a new employee", description = "Should return 200",
+                            value = "{\"id\": 4, \"name\": \"Test User 4\", \"age\": 50, \"organizationId\": 2, \"departmentId\": 3, \"position\": \"tester\"}")
+                })
+          })
+          @Valid Employee employee) {
         LOGGER.info("Employee add: {}", employee);
         return repository.add(employee);
     }
@@ -34,6 +54,17 @@ public class EmployeeController {
     }
 
     @GET
+    @APIResponses(value = {
+          @APIResponse(responseCode = "200", content = {
+                @Content(mediaType = "application/json", examples = {
+                      @ExampleObject(name = "all_persons", value = "[\n" +
+                            "{\"id\": 1, \"name\": \"Test User 1\", \"age\": 20, \"organizationId\": 1, \"departmentId\": 1, \"position\": \"developer\"},\n" +
+                            "{\"id\": 2, \"name\": \"Test User 2\", \"age\": 30, \"organizationId\": 1, \"departmentId\": 2, \"position\": \"architect\"},\n" +
+                            "{\"id\": 3, \"name\": \"Test User 3\", \"age\": 40, \"organizationId\": 2, \"departmentId\": 3, \"position\": \"developer\"},\n" +
+                            "]")
+                })
+          })
+    })
     public Set<Employee> findAll() {
         LOGGER.info("Employee find");
         return repository.findAll();
@@ -41,7 +72,18 @@ public class EmployeeController {
 
     @Path("/department/{departmentId}")
     @GET
-    public Set<Employee> findByDepartment(@PathParam("departmentId") Long departmentId) {
+    @APIResponses(value = {
+          @APIResponse(responseCode = "200", content = {
+                @Content(mediaType = "application/json", examples = {
+                      @ExampleObject(name = "find_by_dep_1", value = "[\n" +
+                            "{ \"id\": 1, \"name\": \"Test User 1\", \"age\": 20, \"organizationId\": 1, \"departmentId\": 1, \"position\": \"developer\" }\n" +
+                            "]")
+                })
+          })
+    })
+    public Set<Employee> findByDepartment(
+          @Parameter(examples = { @ExampleObject(name = "find_by_dep_1", summary = "Main id of department", value = "1") })
+          @PathParam("departmentId") Long departmentId) {
         LOGGER.info("Employee find: departmentId={}", departmentId);
         return repository.findByDepartment(departmentId);
     }


### PR DESCRIPTION
Following your blog post (https://piotrminkowski.com/2023/05/20/contract-testing-on-kubernetes-with-microcks/), here's a suggestion for directly specifying examples within code using annotations.

That way, the `quarkus-smallrye-openapi` plugin directly generates a comprehensive OpenAPI spec file with both information coming from the JAX-RS annotations and completed with information coming from the Microprofile OpenAPI annotations. Generated OpenAPI file can be directly consumed and used by Microcks ;-)

I think this approach fits well with a code-first approach:
* Examples are next to the main code and can be easily adapted as soon as you update the model or the API params,
* It avoids the extra step of editing the generated OpenAPI contract (that may lead to mistakes or typos)

Let me know what you think.